### PR TITLE
Lightweight Flake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,6 @@ authors = [
   "Philipp Schuster <phip1611@gmail.com>"
 ]
 
-[profile.release]
-codegen-units = 1
-opt-level = "s"
-lto = true
-strip = true
-
 [dependencies]
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
 nu-ansi-term = "0.50.0"

--- a/flake.lock
+++ b/flake.lock
@@ -61,29 +61,7 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1720059535,
-        "narHash": "sha256-h/O3PoV3KvQG4tC5UpANBZOsptAZCzEGiwyi+3oSpYc=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "8deeed2dfa21837c7792b46b6a9b2e73f97b472b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "ref": "master",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,19 +7,9 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
-    rust-overlay.url = "github:oxalica/rust-overlay/master";
-    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { self, flake-parts, ... }@inputs:
-    let
-      pkgs = import inputs.nixpkgs {
-        system = "x86_64-linux";
-        overlays = [
-          (inputs.rust-overlay.overlays.default)
-        ];
-      };
-    in
     flake-parts.lib.mkFlake { inherit inputs; }
       {
         flake = {
@@ -35,15 +25,7 @@
         # Don't artificially limit users at this point. If the build fails,
         # they will see soon enough.
         systems = inputs.nixpkgs.lib.systems.flakeExposed;
-        perSystem = { system, self', ... }:
-          let
-            pkgs = import inputs.nixpkgs {
-              inherit system;
-              overlays = [
-                (inputs.rust-overlay.overlays.default)
-              ];
-            };
-          in
+        perSystem = { system, self', pkgs, ... }:
           {
             devShells = {
               default = pkgs.mkShell {
@@ -54,7 +36,7 @@
             packages = rec {
               default = gitlab-timelogs;
               gitlab-timelogs = pkgs.callPackage ./nix/build.nix {
-                crane = inputs.crane.mkLib pkgs;
+                craneLib = inputs.crane.mkLib pkgs;
               };
             };
           };

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -3,6 +3,7 @@
 , lib
 , nix-gitignore
 , openssl
+, iconv
 , pkg-config
 , stdenv
 }:
@@ -17,9 +18,10 @@ let
     ];
     buildInputs = [
       openssl
-    ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-      SystemConfiguration
-    ]);
+    ] ++ lib.optionals stdenv.isDarwin [
+      iconv
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
     # Fix build. Reference:
     # - https://github.com/sfackler/rust-openssl/issues/1430
     # - https://docs.rs/openssl/latest/openssl/

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,18 +1,13 @@
-{ crane
+{ craneLib
 , darwin
 , lib
 , nix-gitignore
 , openssl
 , pkg-config
-, rust-bin
 , stdenv
 }:
 
 let
-  # Toolchain from Rust overlay.
-  rustToolchain = rust-bin.stable.latest.default;
-  craneLib = crane.overrideToolchain rustToolchain;
-
   commonArgs = {
     src = nix-gitignore.gitignoreSource [ ] ../.;
     # Not using this, as this removes the ".graphql" file.


### PR DESCRIPTION
This PR intends to make the flake more lightweight. :feather: 

- It removes `rust-overlay` because the default Rust toolchain is good enough and `rust-overlay` is large.
- It removes LTO (and other) release build microoptimization to reduce build times.

Please take a look at the commit messages for more information.
