### PR TITLE
Add a home-manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ of these systems should work as well.
   - B2: `$ nix run github:phip1611/gitlab-timelogs -- <args>`
 - Option C: add this flake as input and add the package into your system config
 
+**Via home-manager:**
+
+1. import the home-manager module: `gitlab-timelogs.nixosModules.home-manager`
+2. enable and configure gitlab-timelogs:
+
+```nix
+gitlab-timelogs = {
+  enable = true;
+  config = {
+    gitlabHost = "gitlab.example.com";
+    gitlabUsername = "exampleuser";
+    # Either write as a string here, or read from a file that you do not push:
+    gitlabToken = with builtins; readFile (toPath ./gitlab-token.txt);
+  };
+};
+```
+
 ## Usage
 
 - `$ gitlab-timelogs --help`

--- a/flake.nix
+++ b/flake.nix
@@ -13,14 +13,60 @@
     flake-parts.lib.mkFlake { inherit inputs; }
       {
         flake = {
-          nixosModules.default = (
-            { pkgs, ... }:
-            {
-              environment.systemPackages = [
-                self.packages.${pkgs.system}.gitlab-timelogs
-              ];
-            }
-          );
+          nixosModules = {
+            default = ({ pkgs, ... }:
+              {
+                environment.systemPackages = [
+                  self.packages.${pkgs.system}.gitlab-timelogs
+                ];
+              });
+            home-manager = ({ config, pkgs, lib, ... }:
+              let
+                cfg = config.gitlab-timelogs;
+              in
+              {
+                options.gitlab-timelogs = {
+                  enable = lib.mkEnableOption "gitlab-timelogs";
+                  package = lib.mkOption {
+                    type = lib.types.package;
+                    default = self.packages.${pkgs.system}.gitlab-timelogs;
+                  };
+                  config = lib.mkOption {
+                    description = "The values in your config file.";
+                    type = lib.types.submodule {
+                      options = {
+                        gitlabHost = lib.mkOption {
+                          type = lib.types.str;
+                          description = "Gitlab host you want to query.";
+                          example = "gitlab.example.com";
+                        };
+                        gitlabUsername = lib.mkOption {
+                          type = lib.types.str;
+                          description = "Your gitlab username";
+                          example = "exampleuser";
+                        };
+                        gitlabToken = lib.mkOption {
+                          type = lib.types.str;
+                          description = "A gitlab token with read access to the given host.";
+                          example = "glpat-XXXXXXXXXXXXXXXXXXXX";
+                        };
+                      };
+                    };
+                  };
+                };
+                config = lib.mkIf cfg.enable {
+                  home.packages = [
+                    cfg.package
+                  ];
+
+                  home.file.".config/gitlab-timelogs/config.toml".text = ''
+                    gitlab_host = "${cfg.config.gitlabHost}"
+                    gitlab_username = "${cfg.config.gitlabUsername}"
+                    gitlab_token = "${cfg.config.gitlabToken}"
+                  '';
+                };
+              });
+          };
         };
         # Don't artificially limit users at this point. If the build fails,
         # they will see soon enough.


### PR DESCRIPTION
This PR adds a simple home-manager module. This should ease the installation and configuration (although it's already easy). I've also added the necessary documentation.