### PR TITLE
cli: improve error message on expired token

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -85,14 +85,19 @@ fn fetch_result(
     let url = format!("https://{host}/api/graphql", host = host);
     let client = Client::new();
 
-    client
+    match client
         .post(url)
         .header(AUTHORIZATION, authorization)
         .json(&payload)
         .send()
         .unwrap()
-        .json::<Response>()
-        .unwrap()
+        .error_for_status()
+    {
+        Ok(response) => response.json::<Response>().unwrap(),
+        Err(err) => {
+            panic!("Request to Gitlab failed: {err}")
+        }
+    }
 }
 
 /// Fetches all results from the API with pagination in mind.


### PR DESCRIPTION
Slightly improve the error message when an expired token is used. Old experience:

```
thread 'main' panicked at src/fetch.rs:95:10:
called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Decode, source: Error("missing field `data`", line: 1, column: 40) } note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

New experience:

```
thread 'main' panicked at src/fetch.rs:98:13:
Request to Gitlab failed: HTTP status client error (401 Unauthorized) for url (https://gitlab.vpn.cyberus-technology.de/api/graphql) note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It's not perfect, and a better solution would be proper error handling with [anyhow](https://docs.rs/anyhow/latest/anyhow/). But this error message would have already poked me in the right direction.