### PR TITLE
cli: add basic error reporting using anyhow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Unreleased (Yet)
 
+## v0.5.0 (2024-12-17)
+
+- Added basic error reporting. For example, the CLI might now tell you:
+  - ```
+    Error:
+    Failed to parse response body as JSON
+
+    Caused by:
+        0: error decoding response body
+        1: missing field `webUrl2` at line 1 column 308
+    ```
+  - ```
+    Error:
+    Failed to receive proper response
+
+    Caused by:
+        HTTP status client error (401 Unauthorized) for url (https://gitlab.vpn.cyberus-technology.de/api/graphql)
+    ```
+
 ## v0.4.1 (2024-12-17)
 
 - Better error reporting: it is now clearer if the request failed due to a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +374,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 name = "gitlab-timelogs"
 version = "0.4.1"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "nu-ansi-term",
@@ -758,9 +765,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "a2ef2593ffb6958c941575cee70c8e257438749971869c4ae5acf6f91a168a61"
 dependencies = [
  "adler2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ authors = [
 ]
 
 [dependencies]
+anyhow = "1.0.94"
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
 nu-ansi-term = "0.50.0"
 reqwest = { version =  "0.12.4", features = ["blocking", "json"] }


### PR DESCRIPTION
Added basic error reporting. For example, the CLI might now tell you:
  - ```
    Error:
      Failed to parse response body as JSON
      error decoding response body
      missing field `webUrl2` at line 1 column 308
    ```
  - ```
    Error:
      Failed to receive proper response
      HTTP status client error (401 Unauthorized) for url (https://gitlab.vpn.cyberus-technology.de/api/graphql)
    ```